### PR TITLE
Added Directory.Build.targets to use PackageReference instead of direct reference to dll files

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,34 +1,14 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS worker
-
-RUN apt-get update
-RUN apt-get --yes install nuget
-RUN apt-get --yes install dos2unix
-
-RUN mkdir packages
-WORKDIR /packages
-
-# convert run.sh file to unix format
-ADD ./assets/run.sh /user/local/bin/run.sh
-RUN dos2unix /user/local/bin/run.sh
-
-# installing Nuget packages which later be used for analysis
-RUN nuget install SonarAnalyzer.CSharp -Version 8.16.0.25740
-
-# Main image
-# Image used for analysis
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 ENV SOLUTION_FILE_PATH=""
 VOLUME /artifacts
 VOLUME /src
 
-# Move NuGet packages from previous build
-RUN mkdir packages
-WORKDIR /packages
-COPY --from=worker /packages .
+RUN apk add --no-cache dos2unix
 
-# Copy analysis script
-COPY --from=worker /user/local/bin/run.sh /user/local/bin/run.sh
+# convert run.sh file to unix format
+ADD ./assets/run.sh /user/local/bin/run.sh
+RUN dos2unix /user/local/bin/run.sh
 
 # Copy rule set
 WORKDIR /
@@ -38,8 +18,9 @@ ADD ./assets/RuleSet.ruleset /rulesets/RuleSet.ruleset
 #Install targets
 RUN mkdir -p /root/.local/share/Microsoft/MSBuild/Current/Microsoft.Common.targets/ImportBefore
 ADD ./assets/RoslynAnalyzers.targets /root/.local/share/Microsoft/MSBuild/Current/Microsoft.Common.targets/ImportBefore/RoslynAnalyzers.targets
+ADD ./assets/Directory.Build.targets /Directory.Build.targets
 
 WORKDIR /src
 
-CMD ["bash", "/user/local/bin/run.sh"]  
+CMD ["bash", "/user/local/bin/run.sh"]
 

--- a/src/assets/Directory.Build.targets
+++ b/src/assets/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+    <ItemGroup>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" GeneratePathProperty="true">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/src/assets/RoslynAnalyzers.targets
+++ b/src/assets/RoslynAnalyzers.targets
@@ -1,20 +1,24 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
   <Target Name="SetRoslynCodeAnalysisProperties" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <RieRuleSetFilePath>/rulesets/RuleSet.ruleset</RieRuleSetFilePath>
     </PropertyGroup>
     <ItemGroup>
-      <RieAnalyzer Include="/packages/**/analyzers/*.dll" />
+      <RieAnalyzer Include="$(PkgSonarAnalyzer_CSharp)/analyzers/*.dll" />
     </ItemGroup>
+
     <PropertyGroup>
       <ErrorLog>$(TargetDir)$(TargetFileName).roslyn.json</ErrorLog>
       <ResolvedCodeAnalysisRuleSet>$(RieRuleSetFilePath)</ResolvedCodeAnalysisRuleSet>
     </PropertyGroup>
+
     <PropertyGroup>
       <WarningsAsErrors />
       <NoWarn />
       <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     </PropertyGroup>
+
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" />
       <Analyzer Include="@(RieAnalyzer)" />

--- a/src/assets/run.sh
+++ b/src/assets/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh 
 
-dotnet build $SOLUTION_FILE_PATH 
+dotnet build $SOLUTION_FILE_PATH -property:NoWarn=""
+
 shopt -s globstar
 cp -r ./**/*.roslyn.json /artifacts


### PR DESCRIPTION
#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [ ] Major
 - [ ] Minor
 - [x] Patch

#### GITHUB ISSUE LINK
<!--- MANDATORY: Add the GitHub issue url here -->
<!--- Example: #1. Issue will be opened after merging -->
<!--- Example: resolved #2. Issue will be closed after merging -->
Evaluate possibility of using package reference instead of direct reference to dll files https://github.com/GodelTech/CodeReview.Analyzers.Roslyn/issues/7
Add NoWarn parameter to dotnet build command line https://github.com/GodelTech/CodeReview.Analyzers.Roslyn/issues/2

#### IMPACT, DEPENDENCIES AND TEST CONSIDERATIONS
<!--- Describe the likely impact of this change -->
<!--- Describe any dependencies this change may have on other changes in the pipeline, if any -->